### PR TITLE
Fixed `quote` example

### DIFF
--- a/src/String/Extra.elm
+++ b/src/String/Extra.elm
@@ -317,7 +317,7 @@ unsurround wrap string =
 
 {-| Adds quotes to a string.
 
-    quote "foo" == "\"barfoobar\""
+    quote "foo" == "\"foo\""
 
 -}
 quote : String -> String


### PR DESCRIPTION
`quote` currently has an example of:
```elm
quote "foo" == "\"barfoobar\""
```
When it looks like that is a copy-paste error from the `surround` example.  The example for `quote` should be:
```elm
quote "foo" == "\"foo\""
```