### PR TITLE
Add toCodePoints/fromCodePoints

### DIFF
--- a/src/String/Extra.elm
+++ b/src/String/Extra.elm
@@ -37,6 +37,8 @@ module String.Extra
         , leftOfBack
         , fromInt
         , fromFloat
+        , toCodePoints
+        , fromCodePoints
         )
 
 {-| Additional functions for working with Strings
@@ -83,6 +85,10 @@ Functions borrowed from the Rails Inflector class
 
 @docs fromInt, fromFloat
 
+## Converting UTF-32
+
+@docs toCodePoints, fromCodePoints
+
 -}
 
 import String exposing (uncons, cons, words, join)
@@ -90,6 +96,7 @@ import Char exposing (toUpper, toLower)
 import Regex exposing (regex, escape, HowMany(..))
 import Maybe exposing (Maybe(..))
 import List
+import Bitwise
 
 
 {-| Changes the case of the first letter of a string to either Uppercase of
@@ -726,3 +733,162 @@ so if you accidentally pass it something other than a Float, you get an error.
 fromFloat : Float -> String
 fromFloat =
     toString
+
+
+{-| Converts a String into a list of UTF-32 code points.
+
+    toCodePoints "abc" == [ 97, 98, 99 ]
+    toCodePoints "©§π" == [ 169, 167, 960 ]
+
+If every character in the string can be represented by a single UTF-16 code
+unit, `toCodePoints` is equivalent to
+
+    String.toList >> List.map Char.toCode
+
+However, for characters that do not fit into a single UTF-16 code unit and
+have to be represented by a surrogate pair, the above will return each code
+unit in the surrogate pair separately:
+
+    -- 💩 is U+1F4A9 PILE OF POO
+    List.map Char.toCode (String.toList "💩!") == [ 55357, 56489, 33 ]
+
+`toCodePoints detects and combines surrogate pairs of code units to return a
+list of valid UTF-32 code points:
+
+    toCodePoints "💩!" == [ 128169, 33 ]
+
+Note that this still does not necessarily correspond to logical/visual
+characters, since it is possible for things like accented characters to be
+represented as two separate UTF-32 code points (a base character and a
+combining accent).
+-}
+toCodePoints : String -> List Int
+toCodePoints string =
+    let
+        -- Convert a list of UTF-16 code units to a reversed list of UTF-32 code
+        -- points (merging surrogate pairs into single code points where
+        -- necessary)
+        combineAndReverse codeUnits accumulated =
+            case codeUnits of
+                [] ->
+                    accumulated
+
+                first :: afterFirst ->
+                    -- We have at least one code unit - might be a code point
+                    -- itself, or the leading code unit of a surrogate pair
+                    if first >= 0 && first <= 0xD7FF then
+                        -- First code unit is in BMP (and is therefore a valid
+                        -- UTF-32 code point), use it as is and continue with
+                        -- remaining code units
+                        combineAndReverse afterFirst (first :: accumulated)
+                    else if first >= 0xD800 && first <= 0xDBFF then
+                        -- First code unit is a leading surrogate
+                        case afterFirst of
+                            [] ->
+                                -- Should never happen - leading surrogate with
+                                -- no following code unit, discard it
+                                accumulated
+
+                            second :: afterSecond ->
+                                -- Good, there is a following code unit (which
+                                -- should be a trailing surrogate)
+                                if second >= 0xDC00 && second <= 0xDFFF then
+                                    -- Second code unit is a valid trailing
+                                    -- surrogate
+                                    let
+                                        -- Reconstruct UTF-32 code point from
+                                        -- surrogate pair
+                                        codePoint =
+                                            0x00010000
+                                                + ((first - 0xD800) * 1024)
+                                                + (second - 0xDC00)
+                                    in
+                                        -- Continue with following code units
+                                        combineAndReverse afterSecond
+                                            (codePoint :: accumulated)
+                                else
+                                    -- Should never happen - second code unit is
+                                    -- not a valid trailing surrogate, skip the
+                                    -- leading surrogate and continue with
+                                    -- remaining code units (perhaps the second
+                                    -- code unit is a valid leading surrogate or
+                                    -- standalone character, so don't skip it)
+                                    combineAndReverse afterFirst accumulated
+                    else if first >= 0xE000 && first <= 0xFFFF then
+                        -- First code unit is in BMP (and is therefore a valid
+                        -- UTF-32 code point), use it as is and continue with
+                        -- remaining code units
+                        combineAndReverse afterFirst (first :: accumulated)
+                    else
+                        -- Should never happen - first code unit is invalid,
+                        -- skip it and continue with remaining code units
+                        combineAndReverse afterFirst accumulated
+
+        allCodeUnits =
+            List.map Char.toCode (String.toList string)
+    in
+        List.reverse (combineAndReverse allCodeUnits [])
+
+
+{-| Converts a list of UTF-32 code points into a String. Inverse of
+`toCodePoints`.
+
+    fromCodePoints [ 97, 98, 99 ] == "abc"
+    fromCodePoints [ 169, 167, 960 ] == "©§π"
+
+If every code point is a valid UTF-16 code unit, `fromCodePoints` is equivalent
+to
+
+    List.map Char.fromCode >> String.fromList
+
+However, `fromCodePoints` additionally splits code points that do not fit in a
+single UTF-16 code unit into surrogate pairs, so that even code points outside
+the Basic Multilingual Plane (BMP) can be included in the resulting string:
+
+    -- Code point 128169 is 💩, U+1F4A9 PILE OF POO
+    fromCodePoints [ 128169, 33 ] == "💩!"
+-}
+fromCodePoints : List Int -> String
+fromCodePoints allCodePoints =
+    let
+        -- Convert a list of UTF-32 code points into a reversed list of UTF-16
+        -- code units (splitting single code points into surrogate pairs where
+        -- necessary)
+        splitAndReverse codePoints accumulated =
+            case codePoints of
+                [] ->
+                    accumulated
+
+                codePoint :: rest ->
+                    if codePoint >= 0 && codePoint <= 0xD7FF then
+                        -- Code point is valid UTF-16 code unit, use it as is
+                        -- and continue with remaining code points
+                        splitAndReverse rest (codePoint :: accumulated)
+                    else if codePoint >= 0x00010000 && codePoint <= 0x0010FFFF then
+                        -- Code point must be split into a surrogate pair of
+                        -- UTF-16 code units
+                        let
+                            subtracted =
+                                codePoint - 0x00010000
+
+                            leading =
+                                (Bitwise.shiftRight subtracted 10) + 0xD800
+
+                            trailing =
+                                (Bitwise.and subtracted 1023) + 0xDC00
+                        in
+                            splitAndReverse rest
+                                (trailing :: leading :: accumulated)
+                    else if codePoint >= 0xE000 && codePoint <= 0xFFFF then
+                        -- Code point is valid UTF-16 code unit, use it as is
+                        -- and continue with remaining code points
+                        splitAndReverse rest (codePoint :: accumulated)
+                    else
+                        -- Should never happen - invalid code point, skip it and
+                        -- continue with remaining code points
+                        splitAndReverse rest accumulated
+
+        allCodeUnits =
+            List.reverse (splitAndReverse allCodePoints [])
+    in
+        String.fromList (List.map Char.fromCode allCodeUnits)

--- a/tests/Test.elm
+++ b/tests/Test.elm
@@ -13,6 +13,7 @@ import UnderscoredTest exposing (underscoredClaims)
 import DasherizeTest exposing (dasherizeClaims)
 import HumanizeTest exposing (humanizeClaims)
 import UnindentTest exposing (unindentClaims)
+import UnicodeTest exposing (unicodeClaims)
 
 
 toSentenceCaseClaims : Claim
@@ -440,6 +441,7 @@ evidence =
         , ellipsisClaims
         , unquoteClaims
         , wrapClaims
+        , unicodeClaims
         ]
         |> quickCheck
 

--- a/tests/UnicodeTest.elm
+++ b/tests/UnicodeTest.elm
@@ -1,0 +1,132 @@
+module UnicodeTest exposing (unicodeClaims)
+
+import String.Extra exposing (..)
+import String
+import Char
+import Check exposing (Claim, suite, claim, that, is, for, true)
+import Check.Producer exposing (Producer, string, rangeInt, filter, tuple, tuple3, bool, list, map)
+
+
+bmpCodePointProducer : Producer Int
+bmpCodePointProducer =
+    rangeInt 0 0xFFFF
+        |> filter (\value -> value <= 0xD7FF || value >= 0xE000)
+
+
+unicodeStringProducer : Producer String
+unicodeStringProducer =
+    let
+        leadingSurrogateProducer =
+            rangeInt 0xD800 0xDBFF
+
+        trailingSurrogateProducer =
+            rangeInt 0xDC00 0xDFFF
+
+        surrogatePairProducer =
+            tuple ( leadingSurrogateProducer, trailingSurrogateProducer )
+
+        sublistProducer =
+            tuple3 ( bmpCodePointProducer, surrogatePairProducer, bool )
+                |> map
+                    (\( bmpCodePoint, surrogatePair, flag ) ->
+                        if flag then
+                            [ bmpCodePoint ]
+                        else
+                            let
+                                ( leadingSurrogate, trailingSurrogate ) =
+                                    surrogatePair
+                            in
+                                [ leadingSurrogate, trailingSurrogate ]
+                    )
+    in
+        list sublistProducer
+            |> map List.concat
+            |> map (List.map Char.fromCode)
+            |> map String.fromList
+
+
+codePointProducer : Producer Int
+codePointProducer =
+    let
+        astralCodePointProducer =
+            rangeInt 0x00010000 0x0010FFFF
+    in
+        tuple3 ( bmpCodePointProducer, astralCodePointProducer, bool )
+            |> map
+                (\( bmpCodePoint, astralCodePoint, flag ) ->
+                    if flag then
+                        bmpCodePoint
+                    else
+                        astralCodePoint
+                )
+
+
+expectedStringLength : List Int -> Int
+expectedStringLength codePoints =
+    codePoints
+        |> List.map
+            (\codePoint ->
+                if codePoint <= 0xFFFF then
+                    1
+                else
+                    2
+            )
+        |> List.sum
+
+
+hardCodedTestCases : Producer ( String, List Int )
+hardCodedTestCases =
+    rangeInt 0 3
+        |> map
+            (\index ->
+                case index of
+                    1 ->
+                        ( "abc", [ 97, 98, 99 ] )
+
+                    2 ->
+                        ( "©§π", [ 169, 167, 960 ] )
+
+                    3 ->
+                        ( "💩!", [ 128169, 33 ] )
+
+                    _ ->
+                        ( "", [] )
+            )
+
+
+unicodeClaims : Claim
+unicodeClaims =
+    suite "unicode"
+        [ claim "fromCodePoints is inverse of toCodePoints"
+            `that` (toCodePoints >> fromCodePoints)
+            `is` identity
+            `for` unicodeStringProducer
+        , claim "toCodePoints is inverse of fromCodePoints"
+            `that` (fromCodePoints >> toCodePoints)
+            `is` identity
+            `for` (list codePointProducer)
+        , claim "string length is greater than or equal to number of code points"
+            `true` (\codePoints ->
+                        String.length (fromCodePoints codePoints)
+                            >= List.length codePoints
+                   )
+            `for` (list codePointProducer)
+        , claim "number of code points is less than or equal to string length"
+            `true` (\string ->
+                        List.length (toCodePoints string)
+                            <= String.length string
+                   )
+            `for` unicodeStringProducer
+        , claim "encoded string length is as expected"
+            `that` (fromCodePoints >> String.length)
+            `is` expectedStringLength
+            `for` (list codePointProducer)
+        , claim "toCodePoints works as expected on hard-coded test cases"
+            `that` (fst >> toCodePoints)
+            `is` snd
+            `for` hardCodedTestCases
+        , claim "fromCodePoints works as expected on hard-coded test cases"
+            `that` (snd >> fromCodePoints)
+            `is` fst
+            `for` hardCodedTestCases
+        ]


### PR DESCRIPTION
This pull requests adds `toCodePoints` and `fromCodePoints` for converting String values to and from lists of (integer) UTF-32 code points.

These are almost equivalent to `String.toList >> List.map Char.toCode` and `List.map Char.fromCode >> String.fromList` respectively, but add proper handling of UTF-16 surrogate pairs (merged into single UTF-32 code points in `toCodePoints`, generated from UTF-32 code points in `fromCodePoints`).

If you think this would fit better in its own package, I'm happy to do that instead, but this package seemed like as good a home as any.