### PR TITLE
Fix not rendering code example in camelize documentation

### DIFF
--- a/src/String/Extra.elm
+++ b/src/String/Extra.elm
@@ -262,7 +262,7 @@ isBlank string =
 
 {-| Converts underscored or dasherized string to a camelized one.
 
-   camelize "-moz-transform" == "MozTransform"
+    camelize "-moz-transform" == "MozTransform"
 
 -}
 camelize : String -> String


### PR DESCRIPTION
The [current version](http://package.elm-lang.org/packages/elm-community/string-extra/1.3.0/String-Extra#camelize) (1.3.0) does not render the code example correctly for the `camelize` function. This PR fixes this.