### PR TITLE
Documentation: correct ellipsis description and examples

### DIFF
--- a/src/String/Extra.elm
+++ b/src/String/Extra.elm
@@ -235,7 +235,7 @@ softBreakRegexp width =
 
 
 {-| Trims the whitespace of both sides of the string and compresses
-reapeated whitespace internally to a single whitespace char.
+repeated whitespace internally to a single whitespace char.
 
     clean " The   quick brown   fox    " == "The quick brown fox"
 
@@ -281,7 +281,7 @@ camelize string =
 
 
 {-| Converts string to camelized string starting with an uppercase.
-All non word characters will be stripped out of the original string.
+All non-word characters will be stripped out of the original string.
 
     classify "some_class_name" == "SomeClassName"
     classify "myLittleCamel.class.name" == "MyLittleCamelClassName"
@@ -382,7 +382,7 @@ dasherize string =
         |> String.toLower
 
 
-{-| Separates a string into parts of a given width, using a given seperator.
+{-| Separates a string into parts of a given width, using a given separator.
 
 Look at `wrap` if you just want to wrap using newlines.
 
@@ -397,7 +397,7 @@ wrapWith width separator string =
         |> String.join separator
 
 
-{-| Chops a given string into parts of a given width, seperating them using a
+{-| Chops a given string into parts of a given width, separating them using a
 new line.
 
     wrap 7 "My very long text" === "My very\nlong te\nxt"
@@ -410,7 +410,7 @@ wrap width string =
 
 
 {-| Chops a given string into parts of a given width without breaking works apart,
-and then seperating them using a new line.
+and then separating them using a new line.
 
     softWrap 7 "My very long text" === "My very\nlong text"
     softWrap 3 "Hello World" === "Hello \nWorld"
@@ -423,7 +423,7 @@ softWrap width string =
 
 
 {-| Chops a given string into parts of a given width without breaking works apart,
-and then seperating them using the given separator.
+and then separating them using the given separator.
 
     softWrapWith 7 "..." "My very long text" === "My very...long text"
     softWrapWith 3 "\n" "Hello World" === "Hello \nWorld"
@@ -518,11 +518,11 @@ countOccurrences needle haystack =
             |> List.length
 
 
-{-| Truncates the string at the specified lenght and adds the append
-string only if the combined lenght of the truncated string and the append
-string have exactly the desired lenght.
+{-| Truncates the string at the specified length and adds the append
+string only if the combined length of the truncated string and the append
+string have exactly the desired length.
 
-The resulting string will have at most the specified lenght
+The resulting string will have at most the specified length
 
     ellipsisWith 5 " .." "Hello World" == "Hello .."
     ellipsisWith 10 " .."  "Hello World" == "Hello W..."
@@ -539,10 +539,10 @@ ellipsisWith howLong append string =
 
 
 {-| Truncates the string at the specified length and appends
-three dots only if the tructated string + the 3 dots have exactly
-the desired lenght.
+three dots only if the truncated string + the 3 dots have exactly
+the desired length.
 
-The resulting string will have at most the specified lenght
+The resulting string will have at most the specified length
 
     ellipsis 5 "Hello World" == "Hello..."
     ellipsis 10 "Hello World" == "Hello W..."
@@ -556,17 +556,17 @@ ellipsis howLong string =
 
 
 {-| Truncates the string at the specified length and appends
-three dots only if the tructated string + the 3 dots have exactly
-the desired lenght.
+three dots only if the truncated string + the 3 dots have exactly
+the desired length.
 
-In constrast to `ellipsis`, this method will produced unfinished words,
+In contrast to `ellipsis`, this method will produced unfinished words,
 instead, it will find the closest complete word and apply the ellipsis from
 there.
 
 Additionally, it will remove any trailing whitespace and punctuation characters
 at the end of the truncated string.
 
-The resulting stirng can in some cases exceed the specifed lenght, by at most
+The resulting string can in some cases exceed the specified length, by at most
 three characters.
 
     softEllipsis 5 "Hello, World" == "Hello..."

--- a/src/String/Extra.elm
+++ b/src/String/Extra.elm
@@ -518,16 +518,17 @@ countOccurrences needle haystack =
             |> List.length
 
 
-{-| Truncates the string at the specified length and adds the append
-string only if the combined length of the truncated string and the append
-string have exactly the desired length.
+{-| Truncates the second string at the specified length if the string is
+longer than the specified length, and replaces the end of the truncated
+string with the first string, such that the resulting string is of the
+specified length.
 
-The resulting string will have at most the specified length
+The resulting string will have at most the specified length.
 
-    ellipsisWith 5 " .." "Hello World" == "Hello .."
-    ellipsisWith 10 " .."  "Hello World" == "Hello W..."
+    ellipsisWith 5 " .." "Hello World" == "He .."
+    ellipsisWith 10 " .."  "Hello World" == "Hello W .."
     ellipsisWith 10 " .." "Hello" == "Hello"
-    ellipsisWith 8 " .." "Hello World" == "Hello World"
+    ellipsisWith 8 " .." "Hello World" == "Hello .."
 
 -}
 ellipsisWith : Int -> String -> String -> String
@@ -538,16 +539,17 @@ ellipsisWith howLong append string =
         (String.left (howLong - (String.length append)) string) ++ append
 
 
-{-| Truncates the string at the specified length and appends
-three dots only if the truncated string + the 3 dots have exactly
-the desired length.
+{-| Truncates the string at the specified length if the string is
+longer than the specified length, and replaces the end of the truncated
+string with `"..."`, such that the resulting string is of the
+specified length.
 
-The resulting string will have at most the specified length
+The resulting string will have at most the specified length.
 
-    ellipsis 5 "Hello World" == "Hello..."
+    ellipsis 5 "Hello World" == "He..."
     ellipsis 10 "Hello World" == "Hello W..."
     ellipsis 10 "Hello" == "Hello"
-    ellipsis 8 "Hello World" == "Hello World"
+    ellipsis 8 "Hello World" == "Hello..."
 
 -}
 ellipsis : Int -> String -> String
@@ -555,22 +557,20 @@ ellipsis howLong string =
     ellipsisWith howLong "..." string
 
 
-{-| Truncates the string at the specified length and appends
-three dots only if the truncated string + the 3 dots have exactly
-the desired length.
+{-| Truncates the string at the last complete word less than or equal to
+the specified length and appends `"..."`. When the specified length is
+less than the length of the first word, the ellipsis is appended to the
+first word. When the specified length is greater than or equal to the
+length of the string, an identical string is returned.
 
-In contrast to `ellipsis`, this method will produced unfinished words,
-instead, it will find the closest complete word and apply the ellipsis from
-there.
+In contrast to `ellipsis`, this function will not produce incomplete
+words, and the resulting string can exceed the specified length. In
+addition, it removes trailing whitespace and punctuation characters at
+the end of the truncated string.
 
-Additionally, it will remove any trailing whitespace and punctuation characters
-at the end of the truncated string.
-
-The resulting string can in some cases exceed the specified length, by at most
-three characters.
-
+    softEllipsis 1 "Hello, World" == "Hello..."
     softEllipsis 5 "Hello, World" == "Hello..."
-    softEllipsis 8 "Hello, World" == "Hello..."
+    softEllipsis 6 "Hello, World" == "Hello..."
     softEllipsis 15 "Hello, cruel world" == "Hello, cruel..."
     softEllipsis 10 "Hello" == "Hello"
 


### PR DESCRIPTION
The descriptions and examples of `ellipsis`, `ellipsisWith` and `softEllipsis` were inaccurate.

Correct the descriptions and the examples to reflect the actual functions' behaviors.
