### PR TITLE
Replace all whitespace by nothing in failing tests

### DIFF
--- a/tests/CamelizeTest.elm
+++ b/tests/CamelizeTest.elm
@@ -4,6 +4,7 @@ import Char
 import Expect
 import Fuzz exposing (..)
 import Random.Pcg as Random
+import Regex
 import Shrink
 import String
 import String exposing (uncons)
@@ -27,8 +28,11 @@ camelizeTest =
         , fuzz string "It is the same lowercased string after removing the dashes and spaces" <|
             \s ->
                 let
-                    expected =
-                        replace "-" "" >> replace "_" "" >> replace " " "" >> String.toLower
+                    expected = replace "-" ""
+                        >> replace "_" ""
+                        >> replace " " ""
+                        >> Regex.replace Regex.All (Regex.regex "\\s+") (\_ -> "")
+                        >> String.toLower
                 in
                     camelize s
                         |> String.toLower

--- a/tests/CamelizeTest.elm
+++ b/tests/CamelizeTest.elm
@@ -30,7 +30,6 @@ camelizeTest =
                 let
                     expected = replace "-" ""
                         >> replace "_" ""
-                        >> replace " " ""
                         >> Regex.replace Regex.All (Regex.regex "\\s+") (\_ -> "")
                         >> String.toLower
                 in

--- a/tests/HumanizeTest.elm
+++ b/tests/HumanizeTest.elm
@@ -57,8 +57,7 @@ humanizeTest =
             \s ->
                 let
                     expected =
-                        replace " " ""
-                            >> replace "-" ""
+                        replace "-" ""
                             >> replace "_" ""
                             >> Regex.replace Regex.All (Regex.regex "\\s+") (\_ -> "")
                             >> String.toLower

--- a/tests/HumanizeTest.elm
+++ b/tests/HumanizeTest.elm
@@ -60,6 +60,7 @@ humanizeTest =
                         replace " " ""
                             >> replace "-" ""
                             >> replace "_" ""
+                            >> Regex.replace Regex.All (Regex.regex "\\s+") (\_ -> "")
                             >> String.toLower
                 in
                     humanize s


### PR DESCRIPTION
Fixes #25 

I am not entirely sure I am convinced of the use of these fuzzing tests. To me it looks like we are just re-implementing the camelize function for each fuzzed tests, to get our "expected" value. 

Maybe we can replace these tests by parametrized tests where we define an input and expected value in a hardcoded list. That does seem to make more sense to me, at least.

But at least this fixes the failing tests.