### PR TITLE
Remove `replace` as it exists in core from 0.19

### DIFF
--- a/src/String/Extra.elm
+++ b/src/String/Extra.elm
@@ -20,7 +20,6 @@ module String.Extra
         , pluralize
         , quote
         , removeAccents
-        , replace
         , replaceSlice
         , rightOf
         , rightOfBack
@@ -60,7 +59,7 @@ Functions borrowed from the Rails Inflector class
 
 ## Replace and Splice
 
-@docs replace, replaceSlice, insertAt, nonEmpty, nonBlank, removeAccents
+@docs replaceSlice, insertAt, nonEmpty, nonBlank, removeAccents
 
 
 ## Splitting
@@ -157,17 +156,6 @@ toTitleCase ws =
         |> Regex.replace
             (regexFromString "^([a-z])|\\s+([a-z])")
             (.match >> uppercaseMatch)
-
-
-{-| Replace all occurrences of the search string with the substitution string.
-
-    replace "Mary" "Sue" "Hello, Mary" == "Hello, Sue"
-
--}
-replace : String -> String -> String -> String
-replace search substitution string =
-    string
-        |> Regex.replace (regexFromString (regexEscape search)) (\_ -> substitution)
 
 
 {-| Replace text within a portion of a string given a substitution
@@ -301,7 +289,7 @@ classify string =
     string
         |> Regex.replace (regexFromString "[\\W_]") (always " ")
         |> camelize
-        |> replace " " ""
+        |> String.replace " " ""
         |> toSentenceCase
 
 

--- a/tests/CamelizeTest.elm
+++ b/tests/CamelizeTest.elm
@@ -7,7 +7,7 @@ import Random.Pcg as Random
 import Regex
 import Shrink
 import String
-import String exposing (uncons)
+import String exposing (uncons, replace)
 import String.Extra exposing (..)
 import Test exposing (..)
 

--- a/tests/ClassifyTest.elm
+++ b/tests/ClassifyTest.elm
@@ -7,7 +7,7 @@ import Random.Pcg as Random
 import Regex
 import Shrink
 import String
-import String exposing (uncons)
+import String exposing (uncons, replace)
 import String.Extra exposing (..)
 import Test exposing (..)
 import Tuple exposing (first, second)

--- a/tests/DasherizeTest.elm
+++ b/tests/DasherizeTest.elm
@@ -5,7 +5,7 @@ import Expect
 import Fuzz exposing (..)
 import Random.Pcg as Random
 import Shrink
-import String exposing (uncons)
+import String exposing (uncons, replace)
 import String.Extra exposing (..)
 import Test exposing (..)
 

--- a/tests/HumanizeTest.elm
+++ b/tests/HumanizeTest.elm
@@ -45,8 +45,8 @@ humanizeTest =
                     expected =
                         String.toLower
                             >> Regex.replace (Regex.AtMost 1) (Regex.regex "_id$") (\_ -> "")
-                            >> replace "-" " "
-                            >> replace "_" " "
+                            >> String.replace "-" " "
+                            >> String.replace "_" " "
                             >> Regex.replace Regex.All (Regex.regex "\\s+") (\_ -> " ")
                             >> String.trim
                 in
@@ -57,13 +57,13 @@ humanizeTest =
             \s ->
                 let
                     expected =
-                        replace "-" ""
-                            >> replace "_" ""
+                        String.replace "-" ""
+                            >> String.replace "_" ""
                             >> Regex.replace Regex.All (Regex.regex "\\s+") (\_ -> "")
                             >> String.toLower
                 in
                     humanize s
-                        |> replace " " ""
+                        |> String.replace " " ""
                         |> String.toLower
                         |> Expect.equal (expected s)
         , fuzz (validWords []) "It adds a space before each uppercase letter" <|

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -3,7 +3,7 @@ module Tests exposing (..)
 import Expect
 import Fuzz exposing (..)
 import Json.Encode exposing (Value)
-import String exposing (uncons, fromChar, toUpper, toLower)
+import String exposing (uncons, fromChar, toUpper, toLower, replace)
 import String.Extra exposing (..)
 import Test exposing (..)
 import Tuple exposing (first, second)
@@ -114,26 +114,6 @@ toTitleCaseTest =
                             |> String.length
                 in
                     Expect.equal expected result
-        ]
-
-
-replaceTest : Test
-replaceTest =
-    describe "replace"
-        [ fuzz2 string string "It substitutes all occurences of the same sequence" <|
-            \string substitute ->
-                replace string substitute string
-                    |> Expect.equal substitute
-        , fuzz string "It substitutes multiple occurances" <|
-            \string ->
-                replace "a" "b" string
-                    |> String.contains "a"
-                    |> Expect.false "Given string should not contain any 'a'"
-        , test "It should replace special characters" <|
-            \_ ->
-                replace "\\" "deepthought" "this is a special string \\"
-                    |> String.contains "deepthought"
-                    |> Expect.true "String should contain deepthought"
         ]
 
 

--- a/tests/UnderscoredTest.elm
+++ b/tests/UnderscoredTest.elm
@@ -5,7 +5,7 @@ import Expect
 import Fuzz exposing (..)
 import Random.Pcg as Random
 import Shrink
-import String exposing (uncons)
+import String exposing (uncons, replace)
 import String.Extra exposing (..)
 import Test exposing (..)
 


### PR DESCRIPTION
Closes #32.