### PR TITLE
Make String.toTitleCase work with non-english alphabets

### DIFF
--- a/src/String/Extra.elm
+++ b/src/String/Extra.elm
@@ -147,15 +147,8 @@ decapitalize word =
 
 -}
 toTitleCase : String -> String
-toTitleCase ws =
-    let
-        uppercaseMatch =
-            Regex.replace (regexFromString "\\w+") (.match >> toSentenceCase)
-    in
-    ws
-        |> Regex.replace
-            (regexFromString "^([a-z])|\\s+([a-z])")
-            (.match >> uppercaseMatch)
+toTitleCase phrase =
+    phrase |> String.split " " |> List.map String.toSentenceCase |> String.join " "
 
 
 {-| Replace text within a portion of a string given a substitution


### PR DESCRIPTION
The behavior might slightly differ from the original in cases where there's a special character in front of a word. It's a lot simpler though!