### PR TITLE
Add joinMap

### DIFF
--- a/src/String/Extra.elm
+++ b/src/String/Extra.elm
@@ -3,6 +3,7 @@ module String.Extra exposing
     , camelize, classify, underscored, dasherize, humanize
     , replaceSlice, insertAt, nonEmpty, nonBlank, removeAccents
     , break, softBreak
+    , joinMap
     , wrap, wrapWith, softWrap, softWrapWith, quote, surround
     , isBlank, countOccurrences
     , clean, unquote, unsurround, unindent, ellipsis, softEllipsis, ellipsisWith, stripTags, pluralize
@@ -34,6 +35,11 @@ Functions borrowed from the Rails Inflector class
 ## Splitting
 
 @docs break, softBreak
+
+
+## Joining
+
+@docs joinMap
 
 
 ## Wrapping
@@ -203,6 +209,26 @@ softBreak width string =
 softBreakRegexp : Int -> Regex.Regex
 softBreakRegexp width =
     regexFromString <| ".{1," ++ String.fromInt width ++ "}(\\s+|$)|\\S+?(\\s+|$)"
+
+
+{-| A more performant and easier way of writing
+
+    list
+        |> List.map f
+        |> String.join sep
+
+-}
+joinMap : (a -> String) -> String -> List a -> String
+joinMap f sep list =
+    case list of
+        [ only ] ->
+            f only
+
+        first :: rest ->
+            f first ++ sep ++ joinMap f sep rest
+
+        [] ->
+            ""
 
 
 {-| Trim the whitespace of both sides of the string and compress

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,4 +1,23 @@
-module Tests exposing (breakTest, cleanTest, countOccurrencesTest, decapitalizeTest, ellipsisTest, insertAtProducer, insertAtTest, isBlankTest, nonBlankTest, pluralizeTest, softBreakTest, surroundTest, tail, toSentenceCaseTest, toTitleCaseTest, unquoteTest, wrapTest)
+module Tests exposing
+    ( breakTest
+    , cleanTest
+    , countOccurrencesTest
+    , decapitalizeTest
+    , ellipsisTest
+    , insertAtProducer
+    , insertAtTest
+    , isBlankTest
+    , joinMapTest
+    , nonBlankTest
+    , pluralizeTest
+    , softBreakTest
+    , surroundTest
+    , tail
+    , toSentenceCaseTest
+    , toTitleCaseTest
+    , unquoteTest
+    , wrapTest
+    )
 
 import Expect
 import Fuzz exposing (..)
@@ -165,6 +184,20 @@ softBreakTest =
                 softBreak width string
                     |> List.length
                     |> Expect.atMost (String.words string |> List.length)
+        ]
+
+
+joinMapTest : Test
+joinMapTest =
+    describe "joinMap"
+        [ fuzz2 string (list int) "Should yield the same result as List.map combined with String.join" <|
+            \sep list ->
+                Expect.equal
+                    (list
+                        |> List.map String.fromInt
+                        |> String.join sep
+                    )
+                    (joinMap String.fromInt sep list)
         ]
 
 


### PR DESCRIPTION
I was using `List.map` with `String.join` until I realized that that goes through the whole list twice. I tried `List.foldl` but then I realized that couldn't get me the same behaviour as `String.join`, where the separator is only inserted *in between* strings.