### PR TITLE
improve documentation examples for `nonBlank`

### DIFF
--- a/src/String/Extra.elm
+++ b/src/String/Extra.elm
@@ -827,6 +827,8 @@ nonEmpty string =
 
     nonBlank "" == Nothing
 
+    nonBlank " " == Nothing
+
     nonBlank "Hello world" == Just "Hello world"
 
 -}


### PR DESCRIPTION
I almost thought `nonBlank` must be just an alias for `nonEmpty`. However there is difference in how it handles white symbols (since `nonBlank` is using `isBlank` check). I think it's worth illustrating using example.