### PR TITLE
Replace RegEx with version compliant with broader RegEx parsers

### DIFF
--- a/src/String/Extra.elm
+++ b/src/String/Extra.elm
@@ -337,7 +337,7 @@ underscored string =
     string
         |> String.trim
         |> Regex.replace (regexFromString "([a-z\\d])([A-Z]+)") (.submatches >> List.filterMap identity >> String.join "_")
-        |> Regex.replace (regexFromString "[_-\\s]+") (always "_")
+        |> Regex.replace (regexFromString "[_\\s-]+") (always "_")
         |> String.toLower
 
 
@@ -355,7 +355,7 @@ dasherize string =
     string
         |> String.trim
         |> Regex.replace (regexFromString "([A-Z])") (.match >> String.append "-")
-        |> Regex.replace (regexFromString "[_-\\s]+") (always "-")
+        |> Regex.replace (regexFromString "[_\\s-]+") (always "-")
         |> String.toLower
 
 


### PR DESCRIPTION
The RegEx expression `[_-\\s]+` is invalid in many RegEx parsers... and scripts created by Elm will fail when this JS method is run within those environments.

This PR replaces the above expression with `[_\\s-]+` which I believe has the same effect, but does not result in the invalid character range error.

I would also like to back port this to version 1.5.0 if approved.