### PR TITLE
Improve performance for rightOfBack and leftOfBack

### DIFF
--- a/src/String/Extra.elm
+++ b/src/String/Extra.elm
@@ -741,12 +741,17 @@ consisting of the characters in the string that are to the right of the pattern.
 -}
 rightOfBack : String -> String -> String
 rightOfBack pattern string =
-    string
-        |> String.indexes pattern
-        |> List.reverse
-        |> List.head
-        |> Maybe.map ((+) (String.length pattern) >> (\a -> String.dropLeft a string))
-        |> Maybe.withDefault ""
+    case String.indexes pattern string of
+        [] ->
+            ""
+
+        firstIndex :: rest ->
+            case last rest of
+                Just lastIndex ->
+                    String.slice (String.length pattern + lastIndex) (String.length string) string
+
+                Nothing ->
+                    String.slice (String.length pattern + firstIndex) (String.length string) string
 
 
 {-| Search a string from right to left for a pattern and return a substring
@@ -757,12 +762,30 @@ consisting of the characters in the string that are to the left of the pattern.
 -}
 leftOfBack : String -> String -> String
 leftOfBack pattern string =
-    string
-        |> String.indexes pattern
-        |> List.reverse
-        |> List.head
-        |> Maybe.map (\a -> String.left a string)
-        |> Maybe.withDefault ""
+    case String.indexes pattern string of
+        [] ->
+            ""
+
+        firstIndex :: rest ->
+            case last rest of
+                Just lastIndex ->
+                    String.slice 0 lastIndex string
+
+                Nothing ->
+                    String.slice 0 firstIndex string
+
+
+last : List a -> Maybe a
+last items =
+    case items of
+        [] ->
+            Nothing
+
+        [ x ] ->
+            Just x
+
+        _ :: rest ->
+            last rest
 
 
 {-| Convert a string into a list of UTF-32 code points.

--- a/tests/LeftOfBackTest.elm
+++ b/tests/LeftOfBackTest.elm
@@ -1,0 +1,13 @@
+module LeftOfBackTest exposing (leftOfBackTest)
+
+import Expect
+import String.Extra exposing (leftOfBack)
+import Test exposing (Test, test)
+
+
+leftOfBackTest : Test
+leftOfBackTest =
+    test "leftOfBack" <|
+        \() ->
+            leftOfBack "_" "This_is_a_test_string"
+                |> Expect.equal "This_is_a_test"

--- a/tests/RightOfBackTest.elm
+++ b/tests/RightOfBackTest.elm
@@ -1,0 +1,13 @@
+module RightOfBackTest exposing (rightOfBackTest)
+
+import Expect
+import String.Extra exposing (rightOfBack)
+import Test exposing (Test, test)
+
+
+rightOfBackTest : Test
+rightOfBackTest =
+    test "rightOfBack" <|
+        \() ->
+            rightOfBack "_" "This_is_a_test_string"
+                |> Expect.equal "string"


### PR DESCRIPTION
I had a quick look at whether there were functions with "obvious" performance improvements, and came across `rightOfBack` (the `List.reverse` + `List.head` called out to me).

I tried several approaches (that you can go through [in this benchmark](https://github.com/jfmengels/elm-benchmarks/blob/master/src/StringExtra/RightOfBack.elm)). The final benchmark gives the following:
![Screenshot from 2021-11-10 17-26-12](https://user-images.githubusercontent.com/3869412/141153883-1565cc01-bd01-43cf-bd4f-50d8753caa51.png)


` leftOfBack` had a very similar algorithm, so I updated it as well to use the same improvements, with the following results ([benchmark](https://github.com/jfmengels/elm-benchmarks/blob/master/src/StringExtra/LeftOfBack.elm))

![Screenshot from 2021-11-10 17-19-02](https://user-images.githubusercontent.com/3869412/141153998-b98d6632-beca-497a-a08a-1589fe759453.png)

Less impressive, but still a nice improvement.

There were no tests for these 2 functions, so I added basic ones, based on the examples.